### PR TITLE
Fix syntax error due to DCE & add support for non-ascii characters 

### DIFF
--- a/include/Transformation.h
+++ b/include/Transformation.h
@@ -16,7 +16,9 @@ protected:
   virtual void Initialize(clang::ASTContext &Ctx);
 
   std::vector<clang::Stmt *> getAllChildren(clang::Stmt *S);
-
+  bool callOracle();
+  void revertRemoval(const std::vector<clang::SourceRange> &Ranges,
+                    const std::vector<llvm::StringRef> &Reverts);
   void removeSourceText(const clang::SourceLocation &B,
                         const clang::SourceLocation &E);
 

--- a/src/core/Transformation.cpp
+++ b/src/core/Transformation.cpp
@@ -43,7 +43,7 @@ void Transformation::removeSourceText(const clang::SourceLocation &B,
   for (auto const &chr : Text) {
     if (chr == '\n')
       Replacement += '\n';
-    else if (isprint(chr))
+    else if (isprint(chr) || !isascii(chr))
       Replacement += " ";
     else
       Replacement += chr;


### PR DESCRIPTION
This solution solves two problems. 

One problem is related to this issue: https://github.com/aspire-project/chisel/issues/8

Chisel's Dead Code Elimination functionality sometimes removes brackets that are part of the code's syntax. This is due to DCE functionality wrongly taking useful code to be dead code. This causes syntax errors in the reduced files. 

To fix this, I added oracle testing in the classes 'ClangDeadcodeElimination' and 'BlockElimination'. After finding dead code and removing it, I added the condition of running the oracle test script. On an unsuccessful run of oracle test file, indicating an error, I added the condition of reverting the removal of the removed code. My solution follows the same convention used in 'GlobalReduction' and 'LocalReduction' classes to revert the removal of code. This can be seen in this commit https://github.com/aspire-project/chisel/commit/b69352c4e7e97f023011a48f53ef83d075cd2d60
**This fixes the above issue.  https://github.com/aspire-project/chisel/issues/8** 

Another problem is related to this issue: https://github.com/aspire-project/chisel/issues/9

If the code's comments contain non-ascii characters, then incorrect reduction takes place. This is due to the following problem. When GlobalReduction class removes functions declarations during reduction process, it does not remove non-ascii characters from the comments contained in the functions, rather it keeps non-ascii characters and removes the surrounding code of the function. The non-ascii characters left alone without the comments in the resultant code causes syntax errors. Consequently, when delta debugging runs in GlobalReduction, oracle test file gives a negative result. Chisel then takes this reduction to be unsuccessful, and keeps the respective function, regardless if it is redundant or not. 
To fix this, in the removeSourceText function, I added a condition to check if input statements have non-ascii characters in them and replace them with a space ' ' instead of keeping them. This can be seen in this commit https://github.com/aspire-project/chisel/commit/a78fcc9ff62b69f5162b933cf8ca29f62d604b24

**This fixes the above issue. https://github.com/aspire-project/chisel/issues/9** 
